### PR TITLE
Fallback to CFBundleName if CFBundleDisplayName is nil

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -164,7 +164,11 @@ module Fastlane
         build_num = info['CFBundleVersion']
         bundle_id = info['CFBundleIdentifier']
         bundle_version = info['CFBundleShortVersionString']
-        title = CGI.escapeHTML(info['CFBundleDisplayName'])
+        display_name = info['CFBundleDisplayName']
+        if display_name.nil?
+          display_name = info['CFBundleName']
+        end
+        title = CGI.escapeHTML(display_name)
         full_version = "#{bundle_version}.#{build_num}"
 
         # Creating plist and html names


### PR DESCRIPTION
`CFBundleDisplayName` is not set in the default iOS project template.

See https://github.com/joshdholtz/fastlane-plugin-s3/issues/62

I ran into this the other day. My CI server reported a bunch of failed builds when I updated to the latest version of this plugin.