### PR TITLE
Just always show install os instructions :)

### DIFF
--- a/lib/assets/s3_android_html_template.erb
+++ b/lib/assets/s3_android_html_template.erb
@@ -43,6 +43,11 @@
       a:hover {
         text-decoration: underline;
       }
+      #os-message {
+        text-align: center;
+        color: #737373;
+        font-size: 14px;
+      }
       #footnote {
         color: #737373;
         font-size: 14px;
@@ -58,7 +63,6 @@
     <h1 style="text-align: center;"><%= title %></h1>
     <h2><%= version_name %> (<%= version_code %>)</h2>
     <p><em>Built on <%= Time.now.strftime('%a, %e %b %Y %H:%M %p') %></em></p>
-    <!-- <img src="app_icon.png" id="appIcon"> -->
 
     <div class="oneRow">
       <span class="download" id="android">
@@ -70,12 +74,9 @@
       <span class="info">
         <p><%= release_notes %></p>
       </span>
-
-      <!-- <span class="download" id="android">
-      </span> -->
     </div>
 
-    <h3 id="desktop">Please open this page on your Android device!</h3>
+    <h3 id="os-message">Please open this page on your Android device!</h3>
 
     <p id="finished">
       App is being installed. You might have to close the browser.
@@ -84,17 +85,6 @@
     <p id="footnote">
       This is a beta version and is not meant to share with the public.
     </p>
-    <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
+    <img src="https://fastlane.tools/assets/images/fastlane-logo-lockup.png" id="fastlaneLogo" />
   </body>
-
-  <script type='text/javascript'>
-    if (/Android/i.test(navigator.userAgent))
-    {
-      document.getElementById("desktop").remove()
-    }
-    else
-    {
-      document.getElementById("android").remove()
-    }
-  </script>
 </html>

--- a/lib/assets/s3_ios_html_template.erb
+++ b/lib/assets/s3_ios_html_template.erb
@@ -43,6 +43,11 @@
       a:hover {
         text-decoration: underline;
       }
+      #os-message {
+        text-align: center;
+        color: #737373;
+        font-size: 14px;
+      }
       #footnote {
         color: #737373;
         font-size: 14px;
@@ -58,7 +63,6 @@
     <h1 style="text-align: center;"><%= title %></h1>
     <h2><%= bundle_version %> (<%= build_num %>)</h2>
     <p><em>Built on <%= Time.now.strftime('%a, %e %b %Y %H:%M %p') %></em></p>
-    <!-- <img src="app_icon.png" id="appIcon"> -->
 
     <div class="oneRow">
 
@@ -71,12 +75,9 @@
       <span class="info">
         <p><%= release_notes %></p>
       </span>
-
-      <!-- <span class="download" id="android">
-      </span> -->
     </div>
 
-    <h3 id="desktop">Please open this page on your iPhone!</h3>
+    <h3 id="os-message">Please open this page on your iOS device!</h3>
 
     <p id="finished">
       App is being installed. Close Safari using the home button.
@@ -85,24 +86,6 @@
     <p id="footnote">
       This is a beta version and is not meant to share with the public.
     </p>
-    <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
+    <img src="https://fastlane.tools/assets/images/fastlane-logo-lockup.png" id="fastlaneLogo" />
   </body>
-
-  <script type='text/javascript'>
-    // if (/Android/i.test(navigator.userAgent))
-    // {
-    //   document.getElementById("ios").remove()
-    //   document.getElementById("desktop").remove()
-    // }
-    if (/iPhone|iPad|iPod/i.test(navigator.userAgent))
-    {
-      // document.getElementById("android").remove()
-      document.getElementById("desktop").remove()
-    }
-    else
-    {
-      document.getElementById("ios").remove()
-      // document.getElementById("android").remove()
-    }
-  </script>
 </html>


### PR DESCRIPTION
Fixes #79

## Description
- Always show OS install instructions
- Fixed broken fastlane image

<img width="423" alt="Screen Shot 2019-10-01 at 1 10 40 PM" src="https://user-images.githubusercontent.com/401294/65984080-f6286280-e44c-11e9-8f92-98dece21d82f.png">
<img width="428" alt="Screen Shot 2019-10-01 at 1 11 11 PM" src="https://user-images.githubusercontent.com/401294/65984082-f6286280-e44c-11e9-9f0b-572f35123216.png">
