### PR TITLE
Aws sdk v3 modular

### DIFF
--- a/fastlane-plugin-aws_s3.gemspec
+++ b/fastlane-plugin-aws_s3.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 2.3'
+  spec.add_dependency 'aws-sdk', '~> 3.0.1'
   spec.add_dependency 'apktools', '~> 0.7'
-  spec.add_dependency 'mime-types', '~> 3.1'
+  spec.add_dependency 'mime-types', '~> 3.3'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'fastlane', '>= 1.93.1'
+  spec.add_development_dependency 'fastlane', '>= 2.136.0'
 end

--- a/fastlane-plugin-aws_s3.gemspec
+++ b/fastlane-plugin-aws_s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 3.0.1'
+  spec.add_dependency 'aws-sdk-s3', '~> 1'
   spec.add_dependency 'apktools', '~> 0.7'
   spec.add_dependency 'mime-types', '~> 3.3'
 

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -82,7 +82,7 @@ module Fastlane
         UI.user_error!("No IPA, APK file, folder or files paths given, pass using `ipa: 'ipa path'` or `apk: 'apk path'` or `folder: 'folder path' or files: [`file path1`, `file path 2`]") if ipa_file.to_s.length == 0 && apk_file.to_s.length == 0 && files.to_a.count == 0 && folder.to_s.length == 0
         UI.user_error!("Please only give IPA path or APK path (not both)") if ipa_file.to_s.length > 0 && apk_file.to_s.length > 0
 
-        require 'aws-sdk'
+        require 'aws-sdk-s3'
         if s3_profile
           creds = Aws::SharedCredentials.new(profile_name: s3_profile);
         else


### PR DESCRIPTION
Better pull request over [this other one I made](https://github.com/fastlane-community/fastlane-plugin-s3/pull/81). This PR prefers using modular ruby gems instead of the entire AWS sdk ruby gem. It only requires the s3 part that it needs. This will keep the plugin smaller to install and lessons the chance of [this issue](https://github.com/fastlane-community/fastlane-plugin-s3/issues/84) happening again. 

Closes: https://github.com/fastlane-community/fastlane-plugin-s3/issues/71
Fixes: https://github.com/fastlane-community/fastlane-plugin-s3/issues/84