### PR TITLE
AWS Instance Profile Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ You can also customize a lot of options:
 ```ruby
 aws_s3(
   # All of these are used to make Shenzhen's `ipa distribute:s3` command
-  access_key: ENV['S3_ACCESS_KEY'],               # Required from user (unless using aws_profile).
-  secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # Required from user (unless using aws_profile).
-  aws_profile: ENV['AWS_PROFILE']                 # Required from user (unless using access_key and secret_access_key)
+  access_key: ENV['S3_ACCESS_KEY'],               # Optional - defaults to AWS Instance Profile Creds.
+  secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # Optional - defaults to AWS Instance Profile Creds.
+  aws_profile: ENV['AWS_PROFILE']                 # Optional - defaults to AWS Instance Profile Creds. (overrides if access_key and secret_access_key specified)
   bucket: ENV['S3_BUCKET'],                       # Required from user.
   region: ENV['S3_REGION'],                       # Required from user.
   acl: ENV['S3_ACL'],                             # Optional - defaults to 'public-read'
@@ -55,7 +55,7 @@ aws_s3(
 )
 ```
 
-It is recommended to **not** store the AWS access keys in the `Fastfile`.
+It is recommended to **not** store the AWS access keys in the `Fastfile`. You can use [AWS Instance Profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) by attaching IAM roles to your EC2 configurations.
 
 The uploaded `version.json` file provides an easy way for apps to poll if a new update is available. The JSON looks like:
 

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -74,10 +74,6 @@ module Fastlane
         acl     = params[:acl].to_sym
         server_side_encryption = params[:server_side_encryption]
 
-        unless s3_profile
-          UI.user_error!("No S3 access key given, pass using `access_key: 'key'` (or use `aws_profile: 'profile'`)") unless s3_access_key.to_s.length > 0
-          UI.user_error!("No S3 secret access key given, pass using `secret_access_key: 'secret key'` (or use `aws_profile: 'profile'`)") unless s3_secret_access_key.to_s.length > 0
-        end
         UI.user_error!("No S3 bucket given, pass using `bucket: 'bucket'`") unless s3_bucket.to_s.length > 0
         UI.user_error!("No IPA, APK file, folder or files paths given, pass using `ipa: 'ipa path'` or `apk: 'apk path'` or `folder: 'folder path' or files: [`file path1`, `file path 2`]") if ipa_file.to_s.length == 0 && apk_file.to_s.length == 0 && files.to_a.count == 0 && folder.to_s.length == 0
         UI.user_error!("Please only give IPA path or APK path (not both)") if ipa_file.to_s.length > 0 && apk_file.to_s.length > 0
@@ -85,8 +81,12 @@ module Fastlane
         require 'aws-sdk-s3'
         if s3_profile
           creds = Aws::SharedCredentials.new(profile_name: s3_profile);
-        else
+        elsif s3_access_key.to_s.length > 0 && s3_secret_access_key.to_s.length > 0
           creds = Aws::Credentials.new(s3_access_key, s3_secret_access_key)
+        else
+          UI.important("No S3 access key or S3 secret access key given, using S3 instance profile by default.")
+          UI.important("If you want to use specific creds to S3 access, you can pass using `access_key: 'key'` and `secret_access_key: 'secret key'` (or use `aws_profile: 'profile'`)")
+          creds = Aws::InstanceProfileCredentials.new()
         end
         Aws.config.update({
                             region: s3_region,

--- a/spec/s3_action_spec.rb
+++ b/spec/s3_action_spec.rb
@@ -10,24 +10,6 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCARCHIVE_OUTPUT_PATH] = nil
       end
 
-      it "raise an error if no S3 access key was given" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            aws_s3({})
-          end").runner.execute(:test)
-        end.to raise_error("No S3 access key given, pass using `access_key: 'key'` (or use `aws_profile: 'profile'`)")
-      end
-
-      it "raise an error if no S3 secret access key was given" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            aws_s3({
-              access_key: 'access_key'
-              })
-          end").runner.execute(:test)
-        end.to raise_error("No S3 secret access key given, pass using `secret_access_key: 'secret key'` (or use `aws_profile: 'profile'`)")
-      end
-
       it "raise an error if no S3 bucket was given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
This PR contains changes to enable AWS IAM Instance Profiles. 

- `access_key` and `secret_access_key` now optional, AWS Instance Profiles used as default S3 authentication.
- Example section updated in README
- Unnecessary tests removed.

Reviews appreciated.