### PR TITLE
Substitute version in url part/path on Android

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -299,7 +299,7 @@ module Fastlane
         version_name = version[1]
         title = version[2]
 
-        s3_path = "#{version_code}_#{version_name}/" unless s3_path
+        s3_path = "v{version_name}_b{version_code}/" unless s3_path
 
         app_directory = params[:app_directory]
 
@@ -312,7 +312,7 @@ module Fastlane
         version_file_name = params[:version_file_name]
         override_file_name = params[:override_file_name]
 
-        url_part = s3_path
+        url_part = self.expand_path_with_substitutions_with_versions(version_code, version_name, s3_path)
 
         apk_file_basename = File.basename(apk_file)
         apk_file_name = "#{url_part}#{override_file_name ? override_file_name : apk_file_basename}"
@@ -548,6 +548,12 @@ module Fastlane
           path.gsub!(Regexp.new(substitution), value) if value
         end
 
+        return path
+      end
+
+      def self.expand_path_with_substitutions_with_versions(version_code, version_name, path)
+        path.gsub!(/\{version_code\}/, version_code.to_s) if version_code
+        path.gsub!(/\{version_name\}/, version_name) if version_name
         return path
       end
 


### PR DESCRIPTION
Actually, `path` have some substitution from plist data on ios (ipa) upload.
On Android, there is no substitution.

This PR add the ability on Android to use `version_code` & `version_name` as template value to build `path` option.

Now same `s3_path` default pattern is applied on ios & android

- ios : `v{CFBundleShortVersionString}_b{CFBundleVersion}/`
- android : `v{version_name}_b{version_code}/`