### PR TITLE
handle path same as when uploading apk

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -527,7 +527,7 @@ module Fastlane
         files.each do |file|
           file_basename = File.basename(file)
           file_data = File.open(file, 'rb')
-          file_name = url_part + '/' + file_basename
+          file_name = url_part + file_basename
 
           file_url = self.upload_file(s3_client, s3_bucket, app_directory, file_name, file_data, acl, server_side_encryption, download_endpoint, download_endpoint_replacement_regex)
 


### PR DESCRIPTION
Looking at the issue and the commit should be quite clear.

However, note that I tested this for Android and I assumed that iOS uploading works the same as the APK. File uploading is a common feature across iOS and Android obviously.