### PR TITLE
Fix for NoMethodError: `undefined method `escape' for URI:Module (NoMethodError)`

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -176,7 +176,7 @@ module Fastlane
         full_version = "#{bundle_version}.#{build_num}"
 
         # Creating plist and html names
-        plist_file_name ||= "#{url_part}#{URI.escape(title.delete(' '))}.plist"
+        plist_file_name ||= "#{url_part}#{CGI.escape(title.delete(' '))}.plist"
 
         html_file_name ||= "index.html"
 


### PR DESCRIPTION
Add fix for ruby 3 update. Fix missing method `escape' for URI