### PR TITLE
docs: acl options should be hyphenated not underscored

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -765,7 +765,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :acl,
                                        env_name: "S3_ACL",
-                                       description: "Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read ",
+                                       description: "Uploaded object permissions e.g public-read (default), private, public-read-write, authenticated-read ",
                                        optional: true,
                                        default_value: "public-read"),
           FastlaneCore::ConfigItem.new(key: :server_side_encryption,


### PR DESCRIPTION
Fixes #108, if I did anything wrong let me know! Thanks again for everything you all do for fastlane! 😄 

## docs: acl options should be hyphenated not underscored
- public_read -> public-read
- public_read_write -> public-read-write
- authenticated_read -> authenticated-read