### PR TITLE
fixing folder structure when uploading files

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -529,7 +529,13 @@ module Fastlane
         files.each do |file|
           file_basename = File.basename(file)
           file_data = File.open(file, 'rb')
-          file_name = url_part + '/' + file_basename
+          file_name = url_part 
+
+          if file_name.to_s.length > 0 && file_name[-1] != '/'
+              file_name = file_name + '/'
+          end
+          
+          file_name = file_name + file_basename
 
           file_url = self.upload_file(s3_client, s3_bucket, app_directory, file_name, file_data, acl, server_side_encryption, download_endpoint, download_endpoint_replacement_regex)
 


### PR DESCRIPTION
I've noticed that if we had extra `/` in the files name we'd end up with an extra folder named `/`. This is only adding a slash, in case there isn't one already.